### PR TITLE
Add sticky navbar and anchor navigation

### DIFF
--- a/tryon-virtual-style-main/src/components/Benefits.tsx
+++ b/tryon-virtual-style-main/src/components/Benefits.tsx
@@ -23,7 +23,10 @@ const Benefits = () => {
   ];
 
   return (
-    <section className="py-20 px-4 bg-background">
+    <section
+      id="avantages"
+      className="py-20 px-4 bg-background scroll-mt-24"
+    >
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">

--- a/tryon-virtual-style-main/src/components/CTA.tsx
+++ b/tryon-virtual-style-main/src/components/CTA.tsx
@@ -3,7 +3,10 @@ import { ArrowRight } from "lucide-react";
 
 const CTA = () => {
   return (
-    <section className="py-20 px-4 bg-gradient-to-br from-primary/5 via-accent/5 to-primary/5">
+    <section
+      id="contact"
+      className="py-20 px-4 bg-gradient-to-br from-primary/5 via-accent/5 to-primary/5 scroll-mt-24"
+    >
       <div className="max-w-4xl mx-auto text-center space-y-8">
         <h2 className="text-3xl md:text-5xl font-bold text-foreground">
           Prêt à transformer votre boutique ?

--- a/tryon-virtual-style-main/src/components/Hero.tsx
+++ b/tryon-virtual-style-main/src/components/Hero.tsx
@@ -3,7 +3,10 @@ import logoTryon from "@/assets/titre-tryon.png";
 
 const Hero = () => {
   return (
-    <section className="relative min-h-screen flex flex-col items-center justify-center px-4 py-12 bg-gradient-to-b from-background to-secondary/30">
+    <section
+      id="accueil"
+      className="relative min-h-screen flex flex-col items-center justify-center px-4 py-12 bg-gradient-to-b from-background to-secondary/30 scroll-mt-24"
+    >
       <div className="max-w-6xl mx-auto text-center space-y-12">
         {/* Logo */}
         <div className="flex justify-center mb-8 animate-fade-in">

--- a/tryon-virtual-style-main/src/components/Navbar.tsx
+++ b/tryon-virtual-style-main/src/components/Navbar.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { Menu, X } from "lucide-react";
+import logoTryon from "@/assets/titre-tryon.png";
+
+const navLinks = [
+  { href: "#accueil", label: "Accueil" },
+  { href: "#fonctionnalites", label: "Fonctionnalités" },
+  { href: "#temoignages", label: "Témoignages" },
+  { href: "#avantages", label: "Avantages" },
+  { href: "#contact", label: "Contact", isPrimary: true }
+] as const;
+
+const Navbar = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const handleLinkClick = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <header className="sticky top-0 z-50 bg-background/80 backdrop-blur border-b border-border">
+      <nav className="max-w-6xl mx-auto flex items-center justify-between px-4 py-4">
+        <a
+          href="#accueil"
+          className="flex items-center gap-3 text-lg font-semibold text-foreground"
+        >
+          <img
+            src={logoTryon}
+            alt="TryOn"
+            className="h-9 w-auto object-contain md:h-10"
+          />
+          <span className="sr-only">Aller à l'accueil TryOn</span>
+        </a>
+
+        <div className="hidden md:flex items-center gap-6">
+          {navLinks.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              onClick={handleLinkClick}
+              className={`text-sm font-medium transition-colors ${
+                link.isPrimary
+                  ? "px-4 py-2 rounded-full bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
+                  : "text-muted-foreground hover:text-primary"
+              }`}
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setIsOpen((prev) => !prev)}
+          className="md:hidden inline-flex items-center justify-center rounded-full p-2 text-foreground hover:bg-primary/10 transition-colors"
+          aria-label="Ouvrir le menu de navigation"
+          aria-expanded={isOpen}
+        >
+          {isOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
+      </nav>
+
+      {isOpen ? (
+        <div className="md:hidden border-t border-border bg-background/95 backdrop-blur-sm">
+          <div className="px-4 py-4 space-y-2">
+            {navLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                onClick={handleLinkClick}
+                className={`block rounded-lg px-4 py-2 text-base font-medium transition-colors ${
+                  link.isPrimary
+                    ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                    : "text-muted-foreground hover:text-primary hover:bg-primary/5"
+                }`}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </header>
+  );
+};
+
+export default Navbar;

--- a/tryon-virtual-style-main/src/components/ProductPresentation.tsx
+++ b/tryon-virtual-style-main/src/components/ProductPresentation.tsx
@@ -2,7 +2,10 @@ import { Sparkles } from "lucide-react";
 
 const ProductPresentation = () => {
   return (
-    <section className="py-20 px-4 bg-background">
+    <section
+      id="fonctionnalites"
+      className="py-20 px-4 bg-background scroll-mt-24"
+    >
       <div className="max-w-5xl mx-auto">
         <div className="text-center space-y-6">
           <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary font-medium">

--- a/tryon-virtual-style-main/src/components/SocialProof.tsx
+++ b/tryon-virtual-style-main/src/components/SocialProof.tsx
@@ -23,7 +23,10 @@ const SocialProof = () => {
   ];
 
   return (
-    <section className="py-20 px-4 bg-gradient-to-b from-secondary/30 to-background">
+    <section
+      id="temoignages"
+      className="py-20 px-4 bg-gradient-to-b from-secondary/30 to-background scroll-mt-24"
+    >
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-12">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">

--- a/tryon-virtual-style-main/src/pages/Index.tsx
+++ b/tryon-virtual-style-main/src/pages/Index.tsx
@@ -1,3 +1,4 @@
+import Navbar from "@/components/Navbar";
 import Hero from "@/components/Hero";
 import ProductPresentation from "@/components/ProductPresentation";
 import SocialProof from "@/components/SocialProof";
@@ -8,6 +9,7 @@ import Footer from "@/components/Footer";
 const Index = () => {
   return (
     <div className="min-h-screen">
+      <Navbar />
       <Hero />
       <ProductPresentation />
       <SocialProof />


### PR DESCRIPTION
## Summary
- add a sticky, responsive navigation bar with anchor links for key landing page sections
- assign anchor ids and scroll offsets to existing sections to enable smooth in-page navigation
- integrate the new navbar into the index page ahead of the hero section for consistent layout

## Testing
- npm run lint *(fails: existing lint errors in ui components and tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fdc74eb88325a1ab7df719d25d96