### PR TITLE
Add bilingual toggle and adjust hero CTA

### DIFF
--- a/tryon-virtual-style-main/src/App.tsx
+++ b/tryon-virtual-style-main/src/App.tsx
@@ -5,21 +5,24 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { LanguageProvider } from "./contexts/LanguageContext";
 
 const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <LanguageProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </LanguageProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/tryon-virtual-style-main/src/components/Benefits.tsx
+++ b/tryon-virtual-style-main/src/components/Benefits.tsx
@@ -1,44 +1,78 @@
 import { TrendingDown, Heart, Sparkles } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 const Benefits = () => {
-  const benefits = [
-    {
-      icon: TrendingDown,
-      title: "Réduction des retours",
-      description: "Diminuez significativement les retours clients liés aux problèmes de taille et d'ajustement.",
-      gradient: "from-accent/20 to-accent/5"
+  const { language } = useLanguage();
+
+  const content = {
+    fr: {
+      title: "Pourquoi c'est bon pour vous ?",
+      subtitle: "Des avantages business concrets qui transforment votre boutique en ligne",
+      benefits: [
+        {
+          icon: TrendingDown,
+          title: "Réduction des retours",
+          description:
+            "Diminuez significativement les retours clients liés aux problèmes de taille et d'ajustement.",
+          gradient: "from-accent/20 to-accent/5"
+        },
+        {
+          icon: Heart,
+          title: "Satisfaction client optimale",
+          description:
+            "Améliorez l'expérience d'achat et le taux de conversion grâce à la visualisation en temps réel.",
+          gradient: "from-primary/20 to-primary/5"
+        },
+        {
+          icon: Sparkles,
+          title: "Innovation différenciante",
+          description:
+            "Démarquez-vous de la concurrence avec une expérience shopping immersive et moderne.",
+          gradient: "from-accent/20 to-primary/5"
+        }
+      ]
     },
-    {
-      icon: Heart,
-      title: "Satisfaction client optimale",
-      description: "Améliorez l'expérience d'achat et le taux de conversion grâce à la visualisation en temps réel.",
-      gradient: "from-primary/20 to-primary/5"
-    },
-    {
-      icon: Sparkles,
-      title: "Innovation différenciante",
-      description: "Démarquez-vous de la concurrence avec une expérience shopping immersive et moderne.",
-      gradient: "from-accent/20 to-primary/5"
+    en: {
+      title: "Why it works for your business",
+      subtitle: "Tangible business benefits that elevate your online store",
+      benefits: [
+        {
+          icon: TrendingDown,
+          title: "Fewer returns",
+          description: "Significantly cut size and fit-related returns from your customers.",
+          gradient: "from-accent/20 to-accent/5"
+        },
+        {
+          icon: Heart,
+          title: "Happier shoppers",
+          description: "Boost satisfaction and conversions with real-time product visualisation.",
+          gradient: "from-primary/20 to-primary/5"
+        },
+        {
+          icon: Sparkles,
+          title: "Stand-out innovation",
+          description: "Differentiate your brand with an immersive, modern shopping experience.",
+          gradient: "from-accent/20 to-primary/5"
+        }
+      ]
     }
-  ];
+  } as const;
+
+  const t = content[language];
 
   return (
     <section className="py-20 px-4 bg-background">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
-            Pourquoi c'est bon pour vous ?
-          </h2>
-          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Des avantages business concrets qui transforment votre boutique en ligne
-          </p>
+          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">{t.title}</h2>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">{t.subtitle}</p>
         </div>
-        
+
         <div className="grid md:grid-cols-3 gap-8">
-          {benefits.map((benefit, index) => {
+          {t.benefits.map((benefit, index) => {
             const Icon = benefit.icon;
             return (
-              <div 
+              <div
                 key={index}
                 className="group p-8 rounded-2xl bg-card border border-border hover:shadow-2xl transition-all duration-300 hover:-translate-y-2"
               >

--- a/tryon-virtual-style-main/src/components/CTA.tsx
+++ b/tryon-virtual-style-main/src/components/CTA.tsx
@@ -1,32 +1,49 @@
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 const CTA = () => {
+  const { language } = useLanguage();
+
+  const content = {
+    fr: {
+      title: "Prêt à transformer votre boutique ?",
+      description:
+        "Rejoignez les marques innovantes qui révolutionnent l'expérience d'achat de leurs clients avec TryOn.",
+      primary: "S'inscrire dès maintenant",
+      secondary: "Demander une démo",
+      footnote: "🚀 Installation en moins de 5 minutes • Sans engagement • Support dédié"
+    },
+    en: {
+      title: "Ready to transform your store?",
+      description:
+        "Join the innovative brands reinventing their customers' shopping experience with TryOn.",
+      primary: "Sign up now",
+      secondary: "Request a demo",
+      footnote: "🚀 Set up in under 5 minutes • No commitment • Dedicated support"
+    }
+  } as const;
+
+  const t = content[language];
+
   return (
     <section className="py-20 px-4 bg-gradient-to-br from-primary/5 via-accent/5 to-primary/5">
       <div className="max-w-4xl mx-auto text-center space-y-8">
-        <h2 className="text-3xl md:text-5xl font-bold text-foreground">
-          Prêt à transformer votre boutique ?
-        </h2>
-        
-        <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto">
-          Rejoignez les marques innovantes qui révolutionnent l'expérience d'achat 
-          de leurs clients avec TryOn.
-        </p>
-        
+        <h2 className="text-3xl md:text-5xl font-bold text-foreground">{t.title}</h2>
+
+        <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto">{t.description}</p>
+
         <div className="flex flex-col sm:flex-row gap-4 justify-center items-center pt-4">
           <Button variant="cta" size="xl" className="w-full sm:w-auto">
-            S'inscrire dès maintenant
+            {t.primary}
             <ArrowRight className="w-5 h-5" />
           </Button>
           <Button variant="outline" size="xl" className="w-full sm:w-auto">
-            Demander une démo
+            {t.secondary}
           </Button>
         </div>
-        
-        <p className="text-sm text-muted-foreground pt-4">
-          🚀 Installation en moins de 5 minutes • Sans engagement • Support dédié
-        </p>
+
+        <p className="text-sm text-muted-foreground pt-4">{t.footnote}</p>
       </div>
     </section>
   );

--- a/tryon-virtual-style-main/src/components/Footer.tsx
+++ b/tryon-virtual-style-main/src/components/Footer.tsx
@@ -1,6 +1,34 @@
 import logoImage from "@/assets/logo-tryon.png";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 const Footer = () => {
+  const { language } = useLanguage();
+
+  const currentYear = new Date().getFullYear();
+
+  const content = {
+    fr: {
+      links: [
+        { href: "#", label: "Mentions légales" },
+        { href: "#", label: "Politique de confidentialité" },
+        { href: "#", label: "Conditions d'utilisation" },
+        { href: "#", label: "Contact" }
+      ],
+      rights: `© ${currentYear} TryOn. Tous droits réservés.`
+    },
+    en: {
+      links: [
+        { href: "#", label: "Legal notice" },
+        { href: "#", label: "Privacy policy" },
+        { href: "#", label: "Terms of use" },
+        { href: "#", label: "Contact" }
+      ],
+      rights: `© ${currentYear} TryOn. All rights reserved.`
+    }
+  } as const;
+
+  const t = content[language];
+
   return (
     <footer className="py-12 px-4 bg-secondary/50 border-t border-border">
       <div className="max-w-6xl mx-auto">
@@ -14,26 +42,19 @@ const Footer = () => {
             />
             <span className="text-xl font-bold text-foreground">TryOn</span>
           </div>
-          
+
           {/* Links */}
           <div className="flex flex-wrap justify-center gap-6 text-sm text-muted-foreground">
-            <a href="#" className="hover:text-primary transition-colors">
-              Mentions légales
-            </a>
-            <a href="#" className="hover:text-primary transition-colors">
-              Politique de confidentialité
-            </a>
-            <a href="#" className="hover:text-primary transition-colors">
-              Conditions d'utilisation
-            </a>
-            <a href="#" className="hover:text-primary transition-colors">
-              Contact
-            </a>
+            {t.links.map((link) => (
+              <a key={link.label} href={link.href} className="hover:text-primary transition-colors">
+                {link.label}
+              </a>
+            ))}
           </div>
         </div>
-        
+
         <div className="mt-8 pt-8 border-t border-border text-center text-sm text-muted-foreground">
-          <p>© {new Date().getFullYear()} TryOn. Tous droits réservés.</p>
+          <p>{t.rights}</p>
         </div>
       </div>
     </footer>

--- a/tryon-virtual-style-main/src/components/Hero.tsx
+++ b/tryon-virtual-style-main/src/components/Hero.tsx
@@ -1,7 +1,31 @@
 import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/LanguageContext";
 import logoTryon from "@/assets/titre-tryon.png";
 
 const Hero = () => {
+  const { language } = useLanguage();
+
+  const content = {
+    fr: {
+      title: "Réinventez l'expérience d'achat",
+      highlight: "avec l'essayage virtuel",
+      description:
+        "Intégrez en un clic notre solution d'essayage virtuel et offrez à vos clients une expérience shopping immersive et innovante.",
+      cta: "Participer à l'aventure",
+      videoLabel: "Vidéo de présentation du produit"
+    },
+    en: {
+      title: "Reinvent the shopping experience",
+      highlight: "with virtual try-on",
+      description:
+        "Add our virtual fitting solution in just one click and offer your customers an immersive, innovative shopping journey.",
+      cta: "Join the journey",
+      videoLabel: "Product presentation video"
+    }
+  } as const;
+
+  const t = content[language];
+
   return (
     <section className="relative min-h-screen flex flex-col items-center justify-center px-4 py-12 bg-gradient-to-b from-background to-secondary/30">
       <div className="max-w-6xl mx-auto text-center space-y-12">
@@ -17,29 +41,23 @@ const Hero = () => {
         {/* Titre principal */}
         <div className="space-y-6">
           <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-foreground leading-tight">
-            Réinventez l'expérience d'achat
+            {t.title}
             <br />
             <span className="bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
-              avec l'essayage virtuel
+              {t.highlight}
             </span>
           </h1>
-          
-          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
-            Intégrez en un clic notre solution d'essayage virtuel et offrez à vos clients 
-            une expérience shopping immersive et innovante.
-          </p>
+
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">{t.description}</p>
         </div>
-        
+
         {/* CTA */}
-        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center pt-8">
-          <Button variant="hero" size="xl" className="w-full sm:w-auto">
-            S'inscrire dès maintenant
-          </Button>
-          <Button variant="outline" size="xl" className="w-full sm:w-auto">
-            Voir la démo
+        <div className="pt-8 w-full">
+          <Button variant="hero" size="xl" className="w-full">
+            {t.cta}
           </Button>
         </div>
-        
+
         {/* Video placeholder */}
         <div className="mt-16 rounded-2xl overflow-hidden shadow-2xl border border-border bg-card">
           <div className="aspect-video bg-gradient-to-br from-primary/10 to-accent/10 flex items-center justify-center">
@@ -53,7 +71,7 @@ const Hero = () => {
                   <path d="M8 5v14l11-7z" />
                 </svg>
               </div>
-              <p className="text-muted-foreground font-medium">Vidéo de présentation du produit</p>
+              <p className="text-muted-foreground font-medium">{t.videoLabel}</p>
             </div>
           </div>
         </div>

--- a/tryon-virtual-style-main/src/components/LanguageToggle.tsx
+++ b/tryon-virtual-style-main/src/components/LanguageToggle.tsx
@@ -1,0 +1,29 @@
+import { Languages } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const LanguageToggle = () => {
+  const { language, toggleLanguage } = useLanguage();
+
+  const label = language === "fr" ? "English" : "Français";
+  const ariaLabel =
+    language === "fr" ? "Afficher la version anglaise" : "Switch to the French version";
+
+  return (
+    <div className="w-full flex justify-end px-4 pt-4">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={toggleLanguage}
+        className="flex items-center gap-2"
+        type="button"
+        aria-label={ariaLabel}
+      >
+        <Languages className="w-4 h-4" />
+        {label}
+      </Button>
+    </div>
+  );
+};
+
+export default LanguageToggle;

--- a/tryon-virtual-style-main/src/components/ProductPresentation.tsx
+++ b/tryon-virtual-style-main/src/components/ProductPresentation.tsx
@@ -1,56 +1,112 @@
+import type { ReactNode } from "react";
 import { Sparkles } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 const ProductPresentation = () => {
+  const { language } = useLanguage();
+
+  type Feature = {
+    icon: string;
+    title: string;
+    description: string;
+    accent: string;
+  };
+
+  const content: Record<"fr" | "en", { badge: string; title: string; description: ReactNode; features: Feature[] }> = {
+    fr: {
+      badge: "Une intégration ultra-simple",
+      title: "Un plugin léger, un impact puissant",
+      description: (
+        <>
+          TryOn s'intègre en quelques minutes sur votre boutique en ligne. Un simple bouton{" "}
+          <span className="font-semibold text-accent">"ESSAYER"</span>{" "}
+          sur chaque fiche produit permet à vos clients de se visualiser directement avec vos vêtements, où qu'ils soient.
+        </>
+      ),
+      features: [
+        {
+          icon: "⚡",
+          title: "Installation rapide",
+          description: "Intégration en moins de 5 minutes sur votre site e-commerce",
+          accent: "bg-primary/10"
+        },
+        {
+          icon: "🎯",
+          title: "Précision IA",
+          description: "Notre moteur IA offre un rendu réaliste et personnalisé",
+          accent: "bg-accent/10"
+        },
+        {
+          icon: "📱",
+          title: "Multi-plateforme",
+          description: "Compatible desktop, mobile et tablette pour tous vos clients",
+          accent: "bg-primary/10"
+        }
+      ]
+    },
+    en: {
+      badge: "Lightning-fast integration",
+      title: "A lightweight plugin, powerful results",
+      description: (
+        <>
+          TryOn connects to your online store in just a few minutes. A simple{" "}
+          <span className="font-semibold text-accent">"TRY ON"</span>{" "}
+          button on every product page lets shoppers instantly see themselves wearing your collections, wherever they are.
+        </>
+      ),
+      features: [
+        {
+          icon: "⚡",
+          title: "Quick setup",
+          description: "Integrate it with your e-commerce site in under 5 minutes",
+          accent: "bg-primary/10"
+        },
+        {
+          icon: "🎯",
+          title: "AI precision",
+          description: "Our AI engine delivers a realistic and personalised rendering",
+          accent: "bg-accent/10"
+        },
+        {
+          icon: "📱",
+          title: "Multi-platform",
+          description: "Desktop, mobile and tablet compatible for every customer",
+          accent: "bg-primary/10"
+        }
+      ]
+    }
+  };
+
+  const t = content[language];
+
   return (
     <section className="py-20 px-4 bg-background">
       <div className="max-w-5xl mx-auto">
         <div className="text-center space-y-6">
           <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary font-medium">
             <Sparkles className="w-5 h-5" />
-            <span>Une intégration ultra-simple</span>
+            <span>{t.badge}</span>
           </div>
-          
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground">
-            Un plugin léger, un impact puissant
-          </h2>
-          
-          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-            TryOn s'intègre en quelques minutes sur votre boutique en ligne. 
-            Un simple bouton <span className="font-semibold text-accent">"ESSAYER"</span> sur 
-            chaque fiche produit permet à vos clients de se visualiser directement avec vos vêtements, 
-            où qu'ils soient.
-          </p>
-          
+
+          <h2 className="text-3xl md:text-5xl font-bold text-foreground">{t.title}</h2>
+
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">{t.description}</p>
+
           <div className="grid md:grid-cols-3 gap-8 pt-12">
-            <div className="p-6 rounded-xl bg-card border border-border hover:shadow-lg transition-shadow">
-              <div className="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center mb-4 mx-auto">
-                <span className="text-2xl">⚡</span>
+            {t.features.map((feature, index) => (
+              <div
+                key={index}
+                className="p-6 rounded-xl bg-card border border-border hover:shadow-lg transition-shadow"
+              >
+                <div
+                  className={`w-12 h-12 rounded-lg ${feature.accent} flex items-center justify-center mb-4 mx-auto`}
+                >
+                  <span className="text-2xl">{feature.icon}</span>
+                </div>
+                <h3 className="font-semibold text-lg mb-2">{feature.title}</h3>
+                <p className="text-muted-foreground text-sm">{feature.description}</p>
               </div>
-              <h3 className="font-semibold text-lg mb-2">Installation rapide</h3>
-              <p className="text-muted-foreground text-sm">
-                Intégration en moins de 5 minutes sur votre site e-commerce
-              </p>
-            </div>
-            
-            <div className="p-6 rounded-xl bg-card border border-border hover:shadow-lg transition-shadow">
-              <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4 mx-auto">
-                <span className="text-2xl">🎯</span>
-              </div>
-              <h3 className="font-semibold text-lg mb-2">Précision IA</h3>
-              <p className="text-muted-foreground text-sm">
-                Notre moteur IA offre un rendu réaliste et personnalisé
-              </p>
-            </div>
-            
-            <div className="p-6 rounded-xl bg-card border border-border hover:shadow-lg transition-shadow">
-              <div className="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center mb-4 mx-auto">
-                <span className="text-2xl">📱</span>
-              </div>
-              <h3 className="font-semibold text-lg mb-2">Multi-plateforme</h3>
-              <p className="text-muted-foreground text-sm">
-                Compatible desktop, mobile et tablette pour tous vos clients
-              </p>
-            </div>
+            ))}
           </div>
         </div>
       </div>

--- a/tryon-virtual-style-main/src/components/SocialProof.tsx
+++ b/tryon-virtual-style-main/src/components/SocialProof.tsx
@@ -1,45 +1,77 @@
 import { Users, Zap, Cpu } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 const SocialProof = () => {
-  const stats = [
-    {
-      icon: Users,
-      value: "+238",
-      label: "testeurs engagés",
-      color: "text-primary"
+  const { language } = useLanguage();
+
+  const content = {
+    fr: {
+      title: "Une technologie testée et validée",
+      subtitle: "Déjà approuvée par nos utilisateurs, notre solution révolutionne l'expérience d'achat en ligne.",
+      summary: "Une technologie testée, validée et déjà approuvée par nos utilisateurs.",
+      stats: [
+        {
+          icon: Users,
+          value: "+238",
+          label: "testeurs engagés",
+          color: "text-primary"
+        },
+        {
+          icon: Zap,
+          value: "+382",
+          label: "essayages générés",
+          color: "text-accent"
+        },
+        {
+          icon: Cpu,
+          value: "+1",
+          label: "moteur IA sélectionné",
+          color: "text-primary"
+        }
+      ]
     },
-    {
-      icon: Zap,
-      value: "+382",
-      label: "essayages générés",
-      color: "text-accent"
-    },
-    {
-      icon: Cpu,
-      value: "+1",
-      label: "moteur IA sélectionné",
-      color: "text-primary"
+    en: {
+      title: "A proven and trusted technology",
+      subtitle: "Already approved by our users, our solution is reshaping the online shopping experience.",
+      summary: "A technology that's tried, trusted and already embraced by our community.",
+      stats: [
+        {
+          icon: Users,
+          value: "+238",
+          label: "engaged testers",
+          color: "text-primary"
+        },
+        {
+          icon: Zap,
+          value: "+382",
+          label: "virtual try-ons generated",
+          color: "text-accent"
+        },
+        {
+          icon: Cpu,
+          value: "+1",
+          label: "AI engine selected",
+          color: "text-primary"
+        }
+      ]
     }
-  ];
+  } as const;
+
+  const t = content[language];
 
   return (
     <section className="py-20 px-4 bg-gradient-to-b from-secondary/30 to-background">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Une technologie testée et validée
-          </h2>
-          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Déjà approuvée par nos utilisateurs, notre solution révolutionne 
-            l'expérience d'achat en ligne.
-          </p>
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">{t.title}</h2>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">{t.subtitle}</p>
         </div>
-        
+
         <div className="grid md:grid-cols-3 gap-8">
-          {stats.map((stat, index) => {
+          {t.stats.map((stat, index) => {
             const Icon = stat.icon;
             return (
-              <div 
+              <div
                 key={index}
                 className="relative p-8 rounded-2xl bg-card/50 backdrop-blur-sm border border-border shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
               >
@@ -58,11 +90,9 @@ const SocialProof = () => {
             );
           })}
         </div>
-        
+
         <div className="mt-12 text-center">
-          <p className="text-lg font-semibold text-foreground">
-            Une technologie testée, validée et déjà approuvée par nos utilisateurs.
-          </p>
+          <p className="text-lg font-semibold text-foreground">{t.summary}</p>
         </div>
       </div>
     </section>

--- a/tryon-virtual-style-main/src/contexts/LanguageContext.tsx
+++ b/tryon-virtual-style-main/src/contexts/LanguageContext.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+type Language = "fr" | "en";
+
+type LanguageContextValue = {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  toggleLanguage: () => void;
+};
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export const LanguageProvider = ({ children }: { children: ReactNode }) => {
+  const [language, setLanguage] = useState<Language>("fr");
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+      toggleLanguage: () => setLanguage((prev) => (prev === "fr" ? "en" : "fr"))
+    }),
+    [language]
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+
+  return context;
+};

--- a/tryon-virtual-style-main/src/pages/Index.tsx
+++ b/tryon-virtual-style-main/src/pages/Index.tsx
@@ -4,14 +4,16 @@ import SocialProof from "@/components/SocialProof";
 import Benefits from "@/components/Benefits";
 import CTA from "@/components/CTA";
 import Footer from "@/components/Footer";
+import LanguageToggle from "@/components/LanguageToggle";
 
 const Index = () => {
   return (
     <div className="min-h-screen">
+      <LanguageToggle />
       <Hero />
       <ProductPresentation />
-      <SocialProof />
       <Benefits />
+      <SocialProof />
       <CTA />
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- add a language context provider and a top-level toggle to switch between French and English
- localize the hero and marketing sections to react to the selected language and update the hero CTA layout
- reorder the benefits and social proof sections to match the requested presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1211d90d88325a327e241a3a82e06