### PR TITLE
Add sticky navbar and adjust CTA copy

### DIFF
--- a/tryon-virtual-style-main/src/components/Benefits.tsx
+++ b/tryon-virtual-style-main/src/components/Benefits.tsx
@@ -23,7 +23,7 @@ const Benefits = () => {
   ];
 
   return (
-    <section className="py-20 px-4 bg-background">
+    <section id="avantages" className="py-20 px-4 bg-background">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">

--- a/tryon-virtual-style-main/src/components/CTA.tsx
+++ b/tryon-virtual-style-main/src/components/CTA.tsx
@@ -1,9 +1,8 @@
 import { Button } from "@/components/ui/button";
-import { ArrowRight } from "lucide-react";
 
 const CTA = () => {
   return (
-    <section className="py-20 px-4 bg-gradient-to-br from-primary/5 via-accent/5 to-primary/5">
+    <section id="contact" className="py-20 px-4 bg-gradient-to-br from-primary/5 via-accent/5 to-primary/5">
       <div className="max-w-4xl mx-auto text-center space-y-8">
         <h2 className="text-3xl md:text-5xl font-bold text-foreground">
           Prêt à transformer votre boutique ?
@@ -14,14 +13,12 @@ const CTA = () => {
           de leurs clients avec TryOn.
         </p>
         
-        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center pt-4">
-          <Button variant="cta" size="xl" className="w-full sm:w-auto">
-            S'inscrire dès maintenant
-            <ArrowRight className="w-5 h-5" />
-          </Button>
-          <Button variant="outline" size="xl" className="w-full sm:w-auto">
-            Demander une démo
-          </Button>
+        <div className="pt-4">
+          <div className="mx-auto max-w-md">
+            <Button variant="cta" size="xl" className="w-full justify-center">
+              Participer à l'aventure
+            </Button>
+          </div>
         </div>
         
         <p className="text-sm text-muted-foreground pt-4">

--- a/tryon-virtual-style-main/src/components/Hero.tsx
+++ b/tryon-virtual-style-main/src/components/Hero.tsx
@@ -3,7 +3,10 @@ import logoTryon from "@/assets/titre-tryon.png";
 
 const Hero = () => {
   return (
-    <section className="relative min-h-screen flex flex-col items-center justify-center px-4 py-12 bg-gradient-to-b from-background to-secondary/30">
+    <section
+      id="accueil"
+      className="relative min-h-screen flex flex-col items-center justify-center px-4 py-12 bg-gradient-to-b from-background to-secondary/30"
+    >
       <div className="max-w-6xl mx-auto text-center space-y-12">
         {/* Logo */}
         <div className="flex justify-center mb-8 animate-fade-in">
@@ -31,13 +34,12 @@ const Hero = () => {
         </div>
         
         {/* CTA */}
-        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center pt-8">
-          <Button variant="hero" size="xl" className="w-full sm:w-auto">
-            S'inscrire dès maintenant
-          </Button>
-          <Button variant="outline" size="xl" className="w-full sm:w-auto">
-            Voir la démo
-          </Button>
+        <div className="pt-8">
+          <div className="mx-auto max-w-sm">
+            <Button variant="hero" size="xl" className="w-full">
+              Participer à l'aventure
+            </Button>
+          </div>
         </div>
         
         {/* Video placeholder */}

--- a/tryon-virtual-style-main/src/components/Navbar.tsx
+++ b/tryon-virtual-style-main/src/components/Navbar.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import logoTryon from "@/assets/titre-tryon.png";
+
+const navLinks = [
+  { href: "#accueil", label: "Accueil" },
+  { href: "#fonctionnalites", label: "Fonctionnalités" },
+  { href: "#avantages", label: "Pourquoi c'est bon" },
+  { href: "#donnees", label: "Données" },
+  { href: "#contact", label: "Contact" }
+];
+
+const Navbar = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => setIsOpen((prev) => !prev);
+  const closeMenu = () => setIsOpen(false);
+
+  const handleTranslate = () => {
+    const { href } = window.location;
+    const translatedUrl = `https://translate.google.com/translate?sl=fr&tl=en&u=${encodeURIComponent(href)}`;
+    window.open(translatedUrl, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-border bg-background/80 backdrop-blur-md">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4">
+        <a href="#accueil" className="flex items-center gap-3" onClick={closeMenu}>
+          <img src={logoTryon} alt="TryOn" className="h-10 w-auto" />
+          <span className="text-lg font-semibold text-foreground">TryOn</span>
+        </a>
+
+        <nav className="hidden items-center gap-6 text-sm font-medium md:flex">
+          {navLinks.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="hidden items-center gap-3 md:flex">
+          <Button variant="secondary" size="sm" onClick={handleTranslate}>
+            English
+          </Button>
+        </div>
+
+        <button
+          type="button"
+          onClick={toggleMenu}
+          className="inline-flex items-center justify-center rounded-md p-2 text-foreground hover:bg-accent/20 md:hidden"
+          aria-label="Toggle navigation"
+        >
+          {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+        </button>
+      </div>
+
+      {isOpen ? (
+        <div className="md:hidden">
+          <nav className="space-y-2 border-t border-border bg-background px-4 py-4">
+            {navLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                onClick={closeMenu}
+                className="block rounded-md px-3 py-2 text-base font-medium text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
+              >
+                {link.label}
+              </a>
+            ))}
+            <Button variant="secondary" size="sm" className="w-full" onClick={handleTranslate}>
+              English
+            </Button>
+          </nav>
+        </div>
+      ) : null}
+    </header>
+  );
+};
+
+export default Navbar;

--- a/tryon-virtual-style-main/src/components/ProductPresentation.tsx
+++ b/tryon-virtual-style-main/src/components/ProductPresentation.tsx
@@ -2,7 +2,7 @@ import { Sparkles } from "lucide-react";
 
 const ProductPresentation = () => {
   return (
-    <section className="py-20 px-4 bg-background">
+    <section id="fonctionnalites" className="py-20 px-4 bg-background">
       <div className="max-w-5xl mx-auto">
         <div className="text-center space-y-6">
           <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary font-medium">

--- a/tryon-virtual-style-main/src/components/SocialProof.tsx
+++ b/tryon-virtual-style-main/src/components/SocialProof.tsx
@@ -23,7 +23,7 @@ const SocialProof = () => {
   ];
 
   return (
-    <section className="py-20 px-4 bg-gradient-to-b from-secondary/30 to-background">
+    <section id="donnees" className="py-20 px-4 bg-gradient-to-b from-secondary/30 to-background">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-12">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">

--- a/tryon-virtual-style-main/src/pages/Index.tsx
+++ b/tryon-virtual-style-main/src/pages/Index.tsx
@@ -1,3 +1,4 @@
+import Navbar from "@/components/Navbar";
 import Hero from "@/components/Hero";
 import ProductPresentation from "@/components/ProductPresentation";
 import SocialProof from "@/components/SocialProof";
@@ -8,10 +9,11 @@ import Footer from "@/components/Footer";
 const Index = () => {
   return (
     <div className="min-h-screen">
+      <Navbar />
       <Hero />
       <ProductPresentation />
-      <SocialProof />
       <Benefits />
+      <SocialProof />
       <CTA />
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- introduce a sticky Navbar with anchor links and an English translation shortcut
- add anchor ids to landing sections and reorder Benefits before Social Proof
- streamline hero and CTA buttons to a single "Participer à l'aventure" action

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e131a776d8832588016cdd841d3b67