### PR TITLE
Adjust landing page background and copy

### DIFF
--- a/tryon-virtual-style-main/src/components/CTA.tsx
+++ b/tryon-virtual-style-main/src/components/CTA.tsx
@@ -20,7 +20,7 @@ const CTA = () => {
         <div className="flex flex-col sm:flex-row gap-4 justify-center items-center pt-4">
           <Button variant="cta" size="xl" className="w-full sm:w-auto" asChild>
             <a href="mailto:contact@tryon.com?subject=Demande%20d%27inscription%20TryOn">
-              S'inscrire dès maintenant
+              AACtiver mon essai gratuit 15 jours
               <ArrowRight className="w-5 h-5" />
             </a>
           </Button>

--- a/tryon-virtual-style-main/src/components/Hero.tsx
+++ b/tryon-virtual-style-main/src/components/Hero.tsx
@@ -39,7 +39,7 @@ const Hero = () => {
         <div className="flex flex-col sm:flex-row gap-4 justify-center items-center pt-8">
           <Button variant="hero" size="xl" className="w-full sm:w-auto" asChild>
             <a href="#contact">
-              S'inscrire dès maintenant
+              AACtiver mon essai gratuit 15 jours
             </a>
           </Button>
           <Button variant="outline" size="xl" className="w-full sm:w-auto" asChild>

--- a/tryon-virtual-style-main/src/components/Navbar.tsx
+++ b/tryon-virtual-style-main/src/components/Navbar.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Menu, X } from "lucide-react";
 import logoTryon from "@/assets/titre-tryon.png";
-import GoogleTranslateButton from "@/components/GoogleTranslateButton";
 
 const navLinks = [
   { hash: "#accueil", label: "Accueil" },
@@ -62,7 +61,6 @@ const Navbar = () => {
               {link.label}
             </Link>
           ))}
-          <GoogleTranslateButton />
         </div>
 
         <button
@@ -93,7 +91,6 @@ const Navbar = () => {
                 {link.label}
               </Link>
             ))}
-            <GoogleTranslateButton className="w-full justify-center" size="lg" />
           </div>
         </div>
       ) : null}

--- a/tryon-virtual-style-main/src/components/SocialProof.tsx
+++ b/tryon-virtual-style-main/src/components/SocialProof.tsx
@@ -61,12 +61,6 @@ const SocialProof = () => {
             );
           })}
         </div>
-        
-        <div className="mt-12 text-center">
-          <p className="text-lg font-semibold text-foreground">
-            Une technologie testée, validée et déjà approuvée par nos utilisateurs.
-          </p>
-        </div>
       </div>
     </section>
   );

--- a/tryon-virtual-style-main/src/index.css
+++ b/tryon-virtual-style-main/src/index.css
@@ -8,7 +8,7 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
+    --background: 210 20% 98%;
     --foreground: 222 47% 11%;
 
     --card: 0 0% 100%;


### PR DESCRIPTION
## Summary
- set the global background color to the requested #F9FAFB shade
- update hero and CTA buttons to say “AACtiver mon essai gratuit 15 jours”
- remove the English translation button and the redundant approval sentence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f26930807c83259045571b3d65f775