### PR TITLE
Handle missing root element in React entry point

### DIFF
--- a/tryon-virtual-style-main/src/main.tsx
+++ b/tryon-virtual-style-main/src/main.tsx
@@ -1,5 +1,11 @@
 import { createRoot } from "react-dom/client";
-import App from "./App.tsx";
+import App from "./App";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Root element not found. Please ensure index.html contains <div id=\"root\"></div>.");
+}
+
+createRoot(rootElement).render(<App />);


### PR DESCRIPTION
## Summary
- guard the React root lookup to throw a clear error when the container is missing
- import the App component without a TypeScript extension to avoid editor complaints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f4ffcc88888325bb3f2ef8a76cba05