### PR TITLE
Apply dark treatment to plugin presentation band

### DIFF
--- a/tryon-virtual-style-main/src/components/Hero.tsx
+++ b/tryon-virtual-style-main/src/components/Hero.tsx
@@ -1,26 +1,23 @@
 import { Button } from "@/components/ui/button";
 
-const heroImageBase = "https://images.unsplash.com/photo-1545239351-1141bd82e8a6";
-const heroImageParams = "auto=format&fit=crop";
-
 const Hero = () => {
   return (
     <section
       id="accueil"
       className="relative bg-brand-bg px-4 pb-36 pt-24 lg:pt-28"
     >
-      <div className="max-w-6xl mx-auto grid items-center gap-16 lg:grid-cols-2">
-        <div className="space-y-8">
-          <p className="inline-flex items-center rounded-full border border-brand-neutral/70 px-4 py-1 text-sm tracking-wide text-brand-muted">
+      <div className="max-w-5xl mx-auto flex flex-col items-center gap-12 text-center">
+        <div className="space-y-8 w-full">
+          <p className="inline-flex items-center justify-center rounded-full border border-brand-neutral/70 px-4 py-1 text-sm tracking-wide text-brand-muted">
             Pensé pour les équipes e-commerce exigeantes
           </p>
-          <h1>
+          <h1 className="mx-auto max-w-3xl">
             L’essayage virtuel, pensé pour les marques exigeantes.
           </h1>
-          <p className="text-xl text-brand-muted max-w-xl">
+          <p className="mx-auto max-w-3xl text-xl text-brand-muted">
             Une technologie discrète qui révèle l’essentiel : la justesse, la conversion, l’expérience. Vos clients se voient, vous gardez la main sur votre image.
           </p>
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
             <Button size="xl" asChild>
               <a href="#contact">Demander une démo</a>
             </Button>
@@ -33,21 +30,11 @@ const Hero = () => {
           </p>
         </div>
 
-        <div className="relative">
-          {/* Image réaliste pour ancrer le produit dans un univers premium */}
-          <div className="relative overflow-hidden rounded-[1.25rem] border border-brand-neutral bg-white shadow-[var(--shadow-soft)]">
-            <img
-              src={`${heroImageBase}?${heroImageParams}&w=1200&q=80`}
-              srcSet={`${heroImageBase}?${heroImageParams}&w=640&q=80 640w, ${heroImageBase}?${heroImageParams}&w=960&q=80 960w, ${heroImageBase}?${heroImageParams}&w=1200&q=80 1200w`}
-              sizes="(min-width: 1024px) 50vw, 90vw"
-              alt="Interface TryOn intégrée sur une fiche produit sobre"
-              loading="lazy"
-              className="h-full w-full object-cover"
-            />
-          </div>
-          <div className="absolute -bottom-8 left-6 rounded-[1rem] border border-brand-neutral bg-brand-bg px-6 py-4 text-sm text-brand-muted shadow-[var(--shadow-soft)]">
-            <p className="font-medium text-brand-text">Un plugin invisible, mais inoubliable.</p>
-            <p>Essayage morphologique, rendu fidèle, intégration en 10 jours ouvrés.</p>
+        <div className="w-full">
+          <div className="aspect-video w-full overflow-hidden rounded-[1.25rem] border border-dashed border-brand-neutral/60 bg-brand-bg/60 backdrop-blur">
+            <div className="flex h-full w-full items-center justify-center px-8 text-center text-base font-medium text-brand-muted">
+              Zone dédiée à votre vidéo de présentation
+            </div>
           </div>
         </div>
       </div>

--- a/tryon-virtual-style-main/src/components/ProductPresentation.tsx
+++ b/tryon-virtual-style-main/src/components/ProductPresentation.tsx
@@ -1,38 +1,45 @@
-const productImageBase = "https://images.unsplash.com/photo-1542291026-7eec264c27ff";
+const productImageBase = "https://images.unsplash.com/photo-1521572163474-6864f9cf17ab";
 const productImageParams = "auto=format&fit=crop";
 
 const ProductPresentation = () => {
   return (
     <section
       id="experience"
-      className="bg-brand-bg px-4 py-24"
+      className="bg-[#1a1a1a] px-4 py-24"
     >
-      <div className="max-w-6xl mx-auto grid gap-16 lg:grid-cols-[1.1fr_0.9fr]">
+      <div className="max-w-5xl mx-auto flex flex-col items-center gap-12 text-center">
+        <div className="w-full max-w-2xl">
+          <div className="rounded-[1rem] border border-white/10 bg-white/5 px-6 py-6 text-center text-sm text-white/80 shadow-[var(--shadow-soft)]">
+            <p className="text-base font-medium text-white">Un plugin invisible, mais inoubliable.</p>
+            <p className="mt-2">Essayage morphologique, rendu fidèle, intégration en 10 jours ouvrés.</p>
+          </div>
+        </div>
+
         <div className="space-y-6">
-          <h2>Une expérience qui respecte votre identité.</h2>
-          <p className="text-brand-muted text-xl">
+          <h2 className="text-white">Une expérience qui respecte votre identité.</h2>
+          <p className="text-xl text-white/80">
             Le try-on s’intègre sans bruit. Vos clients se voient, vous convertissez — sans dénaturer votre marque.
             Notre équipe ajuste l’interface pour épouser vos guidelines et vos parcours.
           </p>
-          <ul className="space-y-4 text-brand-muted">
-            <li className="flex items-start gap-3">
-              <span className="mt-1 h-2.5 w-2.5 rounded-full bg-brand-accent" aria-hidden="true" />
-              <div>
-                <p className="font-medium text-brand-text">Widget épuré, fond clair</p>
+          <ul className="space-y-4 text-white/70">
+            <li className="flex flex-col items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-brand-accent" aria-hidden="true" />
+              <div className="space-y-1">
+                <p className="font-medium text-white">Widget épuré, fond clair</p>
                 <p>Respecte vos palettes existantes et se fond dans vos templates.</p>
               </div>
             </li>
-            <li className="flex items-start gap-3">
-              <span className="mt-1 h-2.5 w-2.5 rounded-full bg-brand-accent" aria-hidden="true" />
-              <div>
-                <p className="font-medium text-brand-text">Parcours pensé pour la conversion</p>
+            <li className="flex flex-col items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-brand-accent" aria-hidden="true" />
+              <div className="space-y-1">
+                <p className="font-medium text-white">Parcours pensé pour la conversion</p>
                 <p>Bouton d’essayage contextuel, fiche produit préservée, analytics intégrés.</p>
               </div>
             </li>
-            <li className="flex items-start gap-3">
-              <span className="mt-1 h-2.5 w-2.5 rounded-full bg-brand-accent" aria-hidden="true" />
-              <div>
-                <p className="font-medium text-brand-text">Accompagnement clé en main</p>
+            <li className="flex flex-col items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-brand-accent" aria-hidden="true" />
+              <div className="space-y-1">
+                <p className="font-medium text-white">Accompagnement clé en main</p>
                 <p>Onboardings courts, SLA premium, support multilingue pour vos équipes.</p>
               </div>
             </li>
@@ -40,14 +47,54 @@ const ProductPresentation = () => {
         </div>
 
         <div className="relative overflow-hidden rounded-[1.25rem] border border-brand-neutral bg-white shadow-[var(--shadow-soft)]">
-          <img
-            src={`${productImageBase}?${productImageParams}&w=1200&q=80`}
-            srcSet={`${productImageBase}?${productImageParams}&w=640&q=80 640w, ${productImageBase}?${productImageParams}&w=960&q=80 960w, ${productImageBase}?${productImageParams}&w=1200&q=80 1200w`}
-            sizes="(min-width: 1024px) 42vw, 90vw"
-            alt="Visualisation d’une cliente utilisant le service d’essayage TryOn"
-            loading="lazy"
-            className="h-full w-full object-cover"
-          />
+          <div className="flex flex-col gap-6 p-6">
+            <div className="overflow-hidden rounded-2xl bg-brand-neutral/20">
+              <img
+                src={`${productImageBase}?${productImageParams}&w=900&q=80`}
+                srcSet={`${productImageBase}?${productImageParams}&w=600&q=80 600w, ${productImageBase}?${productImageParams}&w=900&q=80 900w, ${productImageBase}?${productImageParams}&w=1200&q=80 1200w`}
+                sizes="(min-width: 1024px) 50vw, 100vw"
+                alt="Présentation produit TryOn - Wine With Me Jacket"
+                loading="lazy"
+                className="h-full w-full object-cover"
+              />
+            </div>
+            <div className="flex w-full flex-col gap-6 text-left">
+              <div className="space-y-2">
+                <p className="text-sm uppercase tracking-[0.3em] text-brand-muted">Wine with me ?</p>
+                <h3 className="text-3xl font-semibold text-brand-text">Jacket</h3>
+                <p className="text-lg font-medium text-brand-text">€129,90 <span className="text-sm text-brand-muted">taxes incluses.</span></p>
+              </div>
+              <div className="space-y-3">
+                <p className="text-sm font-medium uppercase tracking-wide text-brand-text">Taille</p>
+                <div className="grid grid-cols-5 gap-2 text-center text-sm">
+                  {"XS S M L XL".split(" ").map((size) => (
+                    <span
+                      key={size}
+                      className={`rounded-full border border-brand-neutral px-4 py-2 font-medium ${size === "XS" ? "bg-brand-text text-brand-bg" : "text-brand-text"}`}
+                    >
+                      {size}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div className="space-y-2">
+                <button className="w-full rounded-full bg-brand-text px-6 py-3 text-base font-semibold text-brand-bg">
+                  Ajouter au panier
+                </button>
+                <button className="w-full rounded-full border border-brand-neutral px-6 py-3 text-base font-semibold text-brand-text">
+                  Acheter maintenant
+                </button>
+                <button className="w-full rounded-full border border-dashed border-brand-neutral px-6 py-3 text-base font-semibold text-brand-text">
+                  Essayer - TryOn
+                </button>
+              </div>
+              <div className="space-y-2 text-sm text-brand-muted">
+                <p>Expédition</p>
+                <p>Guide des tailles</p>
+                <p>Conseils d’entretien</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- retire la carte plugin de la section héro pour réserver le fond foncé à une zone dédiée
- ajoute un cartouche "Un plugin invisible" au début de la section expérience et applique un fond noir #1a1a1a jusqu’aux bénéfices
- met à jour les couleurs des textes de la section pour garantir le contraste sur fond sombre

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7ce6ef6008325b8f76aa094a06538